### PR TITLE
De-duplicate a peerDependency.

### DIFF
--- a/apps/client/babel.config.js
+++ b/apps/client/babel.config.js
@@ -38,12 +38,12 @@ module.exports = api => {
       'module-resolver',
       {
         alias: {
-          // https://github.com/reduxjs/react-redux/issues/1631
-          // https://github.com/microsoft/redux-dynamic-modules/issues/144
-          'react-redux': path.resolve(
-            __dirname,
-            'node_modules/react-redux/lib'
-          ),
+          // // https://github.com/reduxjs/react-redux/issues/1631
+          // // https://github.com/microsoft/redux-dynamic-modules/issues/144
+          // 'react-redux': path.resolve(
+          //   __dirname,
+          //   'node_modules/react-redux/lib'
+          // ),
         },
       },
     ],

--- a/apps/client/jest.config.js
+++ b/apps/client/jest.config.js
@@ -6,8 +6,8 @@ module.exports = {
   // rootDir: '../..', // This is the monorepo root
 
   testMatch: [
-    projectRoot + '/**/__tests__/**/*.[jt]s?(x)',
-    projectRoot + '/**/?(*.)+(test).[jt]s?(x)',
+    // projectRoot + '/**/__tests__/**/*.[jt]s?(x)',
+    projectRoot + '/**/*.test.ts(x)',
     // '<rootDir>/{ui,utils}/**/?(*.)+(test).[jt]s?(x)',
   ],
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -239,15 +239,17 @@ importers:
       eslint: ~7.32.0
       prettier: ^2.4.1
       react: ^17.0.2
+      react-dom: ^17.0.2
       react-redux: 7.2.2
       redux: 4.0.5
       redux-thunk: ^2.3.0
       typescript: ~4.3.5
     dependencies:
-      '@testing-library/react': 11.2.7_react@17.0.2
+      '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
       core-js: 3.22.3
       react: 17.0.2
-      react-redux: 7.2.2_react@17.0.2+redux@4.0.5
+      react-dom: 17.0.2_react@17.0.2
+      react-redux: 7.2.2_8436876974e3dcafae98d64b636de192
       redux: 4.0.5
       redux-thunk: 2.4.1_redux@4.0.5
     devDependencies:
@@ -2186,19 +2188,6 @@ packages:
       '@testing-library/dom': 7.31.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: true
-
-  /@testing-library/react/11.2.7_react@17.0.2:
-    resolution: {integrity: sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@testing-library/dom': 7.31.2
-      react: 17.0.2
-    dev: false
 
   /@testing-library/user-event/10.4.1:
     resolution: {integrity: sha512-3sdJAfjT0i4aNvo0Gqod5MvZXutMXarVsLtb+r1t65AaRJY7BgMIzWgOtfM5dxRvZsc7IdXnCt9+gcWhiXk1xg==}
@@ -8142,28 +8131,6 @@ packages:
       redux: 4.0.5
     dev: false
 
-  /react-redux/7.2.2_react@17.0.2+redux@4.0.5:
-    resolution: {integrity: sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==}
-    peerDependencies:
-      react: ^16.8.3 || ^17
-      react-dom: '*'
-      react-native: '*'
-      redux: ^2.0.0 || ^3.0.0 || ^4.0.0-0
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.17.9
-      hoist-non-react-statics: 3.3.2
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 17.0.2
-      react-is: 16.13.1
-      redux: 4.0.5
-    dev: false
-
   /react-router-dom/5.3.1_react@17.0.2:
     resolution: {integrity: sha512-f0pj/gMAbv9e8gahTmCEY20oFhxhrmHwYeIwH5EO5xu0qme+wXtsdB8YfUOAZzUz4VaXmb58m3ceiLtjMhqYmQ==}
     peerDependencies:
@@ -9825,8 +9792,16 @@ packages:
       yargs: 13.3.2
     dev: true
 
+  /webpack-combine-loaders/2.0.4:
+    resolution: {integrity: sha512-5O5PYVE5tZ3I3uUm3QB7niLEJzLketl8hvAcJwa4YmwNWS/vixfVsqhtUaBciP8J4u/GwIHV52d7kkgZJFvDnw==}
+    dependencies:
+      qs: 6.10.3
+    dev: true
+
   /webpack-config-utils/2.3.1:
     resolution: {integrity: sha512-0uC5uj7sThFTePTQjfpe5Wqcbw3KSCxqswOmW96lwk2ZI2CU098rWY2ZqOVGJQYJ3hfEltmjcLNkKutw8LJAlg==}
+    dependencies:
+      webpack-combine-loaders: 2.0.4
     dev: true
     bundledDependencies:
       - webpack-combine-loaders

--- a/ui/test-renderer/package.json
+++ b/ui/test-renderer/package.json
@@ -7,6 +7,7 @@
   "module": "src/main.tsx",
   "license": "MIT",
   "dependencies": {
+    "react-dom": "^17.0.2",
     "react": "^17.0.2",
     "@testing-library/react": "^11.1.0",
     "react-redux": "7.2.2",


### PR DESCRIPTION
This PR fixes the issue (at least locally for me).

The line that actually fixes the issue is the addition of the `react-dom` dependency to `ui/test-renderer`. This removes a second installed copy of `react-redux`. I suspect the issue involves a singleton in that package, and having two installed copies of the package (with two different sets of peer dependencies) introduced a second copy of that singleton.